### PR TITLE
Fix compatibility for drops mod

### DIFF
--- a/items/moving_item.lua
+++ b/items/moving_item.lua
@@ -139,7 +139,7 @@ minetest.register_entity("factory:moving_item", {
 		else
 			local stack = ItemStack(self.itemstring)
 			local veldir = self.object:getvelocity();
-			minetest.item_drop(stack, factory.no_player, {x = pos.x + veldir.x / 3, y = pos.y, z = pos.z + veldir.z / 3})
+			minetest.add_item({x = pos.x + veldir.x / 3, y = pos.y, z = pos.z + veldir.z / 3}, stack)
 			self.object:remove()
 		end
 	end


### PR DESCRIPTION
Fix a crash when using drops mod (https://github.com/jordan4ibanez/drops) relating to items reaching the end of a conveyor belt calling item_drop.