### PR TITLE
Added NEI compat, code quality

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -10,3 +10,10 @@ read_globals = {
 	"unified_inventory",
 	math = { fields = {"sign"} }
 }
+
+globals = {
+	"factory", "factory_gui_bg", "factory_gui_bg_img", "factory_gui_bg_img_2",
+	"factory_gui_slots"
+}
+
+files["util/compat_nei.lua"].read_globals = {"api"}

--- a/decor/smoketube.lua
+++ b/decor/smoketube.lua
@@ -31,7 +31,7 @@ minetest.register_node("factory:smoke_tube", {
 
 factory.smoke_spawners = {}
 
-function get_smoke_spawner_at(pos)
+local function get_smoke_spawner_at(pos)
 	for _,sp in pairs(factory.smoke_spawners) do
 		if vector.equals(sp.pos,pos) then
 			return sp

--- a/depends.txt
+++ b/depends.txt
@@ -4,3 +4,4 @@ unified_inventory?
 moreores?
 extranodes?
 technic_worldgen?
+nei?

--- a/machines/oarm.lua
+++ b/machines/oarm.lua
@@ -2,7 +2,7 @@ local S = factory.S
 local insert = factory.insert_object_item
 local count_index = factory.count_index
 
-function oarm_handle (a, b, target, stack, obj)
+local function oarm_handle (a, b, target, stack, obj)
 	--throws anything that is already in the inventory (more than one stack) out
 	if factory.has_main_inv(target) then
 		local meta = minetest.env:get_meta(b)

--- a/machines/qarm.lua
+++ b/machines/qarm.lua
@@ -1,7 +1,7 @@
 local S = factory.S
 local insert = factory.insert_object_item
 
-function qarm_handle (a, b, target, stack, minv, obj)
+local function qarm_handle (a, b, target, stack, minv, obj)
 	local found = false
 	if factory.has_main_inv(target) then
 		local meta = minetest.env:get_meta(b)

--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,4 @@
 name = factory
 description = New Factory! Adds lots of industrials to minetest to create big factories.
 depends = modutil
-optional_depends = moreblocks,unified_inventory,moreores,extranodes,technic_worldgen
+optional_depends = moreblocks,unified_inventory,moreores,extranodes,technic_worldgen,nei

--- a/util/compat_nei.lua
+++ b/util/compat_nei.lua
@@ -1,0 +1,46 @@
+local recipes = api and api.recipes or nil -- when NEI mod is not loaded, it's nil
+local S = factory.S
+
+function factory.register_nei_recipe(typename, index) -- adds "Fake" recipe
+	if not api then return end
+	if not recipes.methods[typename] then
+		factory.log.warning("Not registered NEI Handler: " .. typename)
+		return
+	end
+
+	local recipe = factory.recipes[typename].recipes[index]
+	local i,o,d = recipe.input, recipe.output, {time = recipe.time}
+	if type(o) ~= table then
+		o = {o} -- at least output is in (almost) the same form
+	end
+
+	local i2 = {}
+	for k,v in pairs(i) do
+		i2[#i2 + 1] = k .. " " .. v -- I have itemstacks in input even though I should use itemmaps
+	end
+	recipes.add(typename, i2, o, d)
+end
+
+-- I decided to hardcode handlers for now because factory.register_craft_type API is broken (width, height, icon...)
+-- If a handler for a method is not registered, it will log a warning whenever recipe with that method is registered
+-- Will rewrite this so it's automatic when the API stabilizes (when args in crafting.lua will be the same as in the
+-- factory.register_craft_type)
+local function register_1x1_method(name, desc, machine)
+	if not api then return end
+	recipes.add_method(name, {
+		input_amount = 1,
+		output_amount = 1,
+		get_input_coords = recipes.coord_getter(1, -1, 0),
+		get_output_coords = recipes.coord_getter(1, 1, 0),
+		formspec_width = 5,
+		formspec_height = 4,
+		formspec_name = desc,
+		formspec_begin = function(data)
+			return ("image[1,1;1,1;gui_ind_furnace_arrow_bg.png^[transformR270]textarea[0.25,2.25;4.5,1.5;;;%s]")
+					:format(api.S("Time: @1 seconds", data.time))
+		end,
+	})
+	recipes.add_implementor(name, machine)
+end
+register_1x1_method("ind_squeezer", S"Industrial Squeezer", "factory:ind_squeezer")
+register_1x1_method("wire_drawer", S"Wire Drawer", "factory:wire_drawer")

--- a/util/craftingutil.lua
+++ b/util/craftingutil.lua
@@ -1,5 +1,6 @@
 --- the modpath of unified inventoy or nil
 local have_ui = minetest.get_modpath("unified_inventory")
+local have_nei = minetest.get_modpath("nei")
 
 --- the recipe table containing all factory recipes
 factory.recipes = { cooking = { input_size = 1, output_size = 1 } }
@@ -69,6 +70,10 @@ local function register_recipe(typename, data)
 			items = data.input,
 			width = 0,
 		})
+	end
+	if have_nei then
+		-- quite inefficient because table is processed again to get 3 tables instead of 1 (the NEI recipe form)
+		factory.register_nei_recipe(typename, index)
 	end
 end
 

--- a/util/init.lua
+++ b/util/init.lua
@@ -9,3 +9,5 @@ factory.require("util/nodes")
 if minetest.settings:get_bool("factory_fertilizerGeneration") or true then
 	factory.require("util/gen")
 end
+
+factory.require("util/compat_nei") -- does nothing when there's no NEI


### PR DESCRIPTION
I added compatibility between this mod and NeverEnoughItems, my inventory/recipe viewer mod (similar to UnifiedInventory, used in Wastelands Survival now).

So, in order to work, I need three things:
- First, NEI must be loaded before this to patch minetest's `register_craft` function ([this](https://gitlab.com/trinium-mods/neverenoughitems/blob/master/nei/code/recipe_compat.lua#L90)).
- Second - NEI recipe method has to be added for each machine ([here](https://github.com/MultiDragon/factory/commit/99a99611cca23b63e41fa709d47bb26cc917265a#diff-e15ae38b5669b6556019d7afb00add49R28)). I decided to add methods (for Squeezer and Wiremill) manually for now because `factory.register_craft_type` is strange - arguments that it uses aren't present in the part of code adding the craft types. I can do that if needed later (when that issue is fixed).
- Third - NEI recipe has to be added to mod for each actual recipe ([here](https://github.com/MultiDragon/factory/commit/99a99611cca23b63e41fa709d47bb26cc917265a#diff-e15ae38b5669b6556019d7afb00add49R4)). The recipes are automatically generated from `factory.register_recipe`.

Also this commit fixes a few code quality issues (like having global `qarm_handle`).

EDIT: when NEI is not present, everything works as before.